### PR TITLE
Squashed SW renderer upscaler

### DIFF
--- a/src/core/gpu.cpp
+++ b/src/core/gpu.cpp
@@ -229,7 +229,7 @@ bool GPU::DoState(StateWrapper& sw, HostDisplayTexture** host_texture, bool upda
     else
     {
       ReadVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT);
-      sw.DoBytes(m_vram_ptr, VRAM_WIDTH * VRAM_HEIGHT * sizeof(u16));
+      sw.DoBytes(GetVRAMshadowPtr(), VRAM_WIDTH * VRAM_HEIGHT * sizeof(u16));
     }
   }
 
@@ -967,6 +967,8 @@ u32 GPU::ReadGPUREAD()
   if (m_blitter_state != BlitterState::ReadingVRAM)
     return m_GPUREAD_latch;
 
+  auto m_vram_ptr = GetVRAMshadowPtr();
+
   // Read two pixels out of VRAM and combine them. Zero fill odd pixel counts.
   u32 value = 0;
   for (u32 i = 0; i < 2; i++)
@@ -1245,6 +1247,8 @@ void GPU::ReadVRAM(u32 x, u32 y, u32 width, u32 height) {}
 
 void GPU::FillVRAM(u32 x, u32 y, u32 width, u32 height, u32 color)
 {
+  auto m_vram_ptr = GetVRAMshadowPtr();
+
   const u16 color16 = VRAMRGBA8888ToRGBA5551(color);
   if ((x + width) <= VRAM_WIDTH && !IsInterlacedRenderingEnabled())
   {
@@ -1292,6 +1296,8 @@ void GPU::FillVRAM(u32 x, u32 y, u32 width, u32 height, u32 color)
 
 void GPU::UpdateVRAM(u32 x, u32 y, u32 width, u32 height, const void* data, bool set_mask, bool check_mask)
 {
+  auto m_vram_ptr = GetVRAMshadowPtr();
+
   // Fast path when the copy is not oversized.
   if ((x + width) <= VRAM_WIDTH && (y + height) <= VRAM_HEIGHT && !set_mask && !check_mask)
   {
@@ -1328,6 +1334,8 @@ void GPU::UpdateVRAM(u32 x, u32 y, u32 width, u32 height, const void* data, bool
 
 void GPU::CopyVRAM(u32 src_x, u32 src_y, u32 dst_x, u32 dst_y, u32 width, u32 height)
 {
+  auto m_vram_ptr = GetVRAMshadowPtr();
+
   // Break up oversized copies. This behavior has not been verified on console.
   if ((src_x + width) > VRAM_WIDTH || (dst_x + width) > VRAM_WIDTH)
   {
@@ -1472,11 +1480,11 @@ bool GPU::DumpVRAMToFile(const char* filename)
   const char* extension = std::strrchr(filename, '.');
   if (extension && StringUtil::Strcasecmp(extension, ".png") == 0)
   {
-    return DumpVRAMToFile(filename, VRAM_WIDTH, VRAM_HEIGHT, sizeof(u16) * VRAM_WIDTH, m_vram_ptr, true);
+    return DumpVRAMToFile(filename, VRAM_WIDTH, VRAM_HEIGHT, sizeof(u16) * VRAM_WIDTH, GetVRAMshadowPtr(), true);
   }
   else if (extension && StringUtil::Strcasecmp(extension, ".bin") == 0)
   {
-    return FileSystem::WriteBinaryFile(filename, m_vram_ptr, VRAM_WIDTH * VRAM_HEIGHT * sizeof(u16));
+    return FileSystem::WriteBinaryFile(filename, GetVRAMshadowPtr(), VRAM_WIDTH * VRAM_HEIGHT * sizeof(u16));
   }
   else
   {

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -74,6 +74,7 @@ public:
   virtual ~GPU();
 
   virtual bool IsHardwareRenderer() const = 0;
+  virtual u16* GetVRAMshadowPtr() = 0;
 
   virtual bool Initialize(HostDisplay* host_display);
   virtual void Reset(bool clear_vram);
@@ -317,7 +318,7 @@ protected:
   std::unique_ptr<TimingEvent> m_command_tick_event;
 
   // Pointer to VRAM, used for reads/writes. In the hardware backends, this is the shadow buffer.
-  u16* m_vram_ptr = nullptr;
+  //u16* m_vram_ptr = nullptr;
 
   union GPUSTAT
   {

--- a/src/core/gpu_backend.h
+++ b/src/core/gpu_backend.h
@@ -19,13 +19,14 @@ public:
   GPUBackend();
   virtual ~GPUBackend();
 
-  ALWAYS_INLINE u16* GetVRAM() const { return m_vram_ptr; }
+  virtual u16* GetVRAMshadowPtr() = 0;
 
   virtual bool Initialize();
   virtual void UpdateSettings();
   virtual void Reset(bool clear_vram);
   virtual void Shutdown();
 
+  GPUBackendReadVRAMCommand* NewReadVRAMCommand();
   GPUBackendFillVRAMCommand* NewFillVRAMCommand();
   GPUBackendUpdateVRAMCommand* NewUpdateVRAMCommand(u32 num_words);
   GPUBackendCopyVRAMCommand* NewCopyVRAMCommand();
@@ -35,7 +36,7 @@ public:
   GPUBackendDrawLineCommand* NewDrawLineCommand(u32 num_vertices);
 
   void PushCommand(GPUBackendCommand* cmd);
-  void Sync();
+  virtual void Sync(bool allow_sleep);
 
   /// Processes all pending GPU commands.
   void RunGPULoop();
@@ -47,6 +48,7 @@ protected:
   void StartGPUThread();
   void StopGPUThread();
 
+  virtual void ReadVRAM(u32 x, u32 y, u32 width, u32 height) {}
   virtual void FillVRAM(u32 x, u32 y, u32 width, u32 height, u32 color, GPUBackendCommandParameters params) = 0;
   virtual void UpdateVRAM(u32 x, u32 y, u32 width, u32 height, const void* data,
                           GPUBackendCommandParameters params) = 0;
@@ -59,8 +61,6 @@ protected:
   virtual void DrawingAreaChanged() = 0;
 
   void HandleCommand(const GPUBackendCommand* cmd);
-
-  u16* m_vram_ptr = nullptr;
 
   Common::Rectangle<u32> m_drawing_area{};
 

--- a/src/core/gpu_commands.cpp
+++ b/src/core/gpu_commands.cpp
@@ -575,6 +575,7 @@ bool GPU::HandleCopyRectangleVRAMToCPUCommand()
 
   if (g_settings.debugging.dump_vram_to_cpu_copies)
   {
+    auto m_vram_ptr = GetVRAMshadowPtr();
     DumpVRAMToFile(StringUtil::StdStringFromFormat("vram_to_cpu_copy_%u.png", s_vram_to_cpu_dump_id++).c_str(),
                    m_vram_transfer.width, m_vram_transfer.height, sizeof(u16) * VRAM_WIDTH,
                    &m_vram_ptr[m_vram_transfer.y * VRAM_WIDTH + m_vram_transfer.x], true);

--- a/src/core/gpu_hw.cpp
+++ b/src/core/gpu_hw.cpp
@@ -31,7 +31,6 @@ ALWAYS_INLINE static bool ShouldUseUVLimits()
 
 GPU_HW::GPU_HW() : GPU()
 {
-  m_vram_ptr = m_vram_shadow.data();
 }
 
 GPU_HW::~GPU_HW() = default;

--- a/src/core/gpu_hw.h
+++ b/src/core/gpu_hw.h
@@ -38,6 +38,8 @@ public:
   void UpdateResolutionScale() override final;
   std::tuple<u32, u32> GetEffectiveDisplayResolution() override final;
 
+  u16* GetVRAMshadowPtr() override { return m_vram_shadow.data(); }
+
 protected:
   enum : u32
   {

--- a/src/core/gpu_hw_d3d11.cpp
+++ b/src/core/gpu_hw_d3d11.cpp
@@ -187,7 +187,7 @@ void GPU_HW_D3D11::UpdateSettings()
   if (framebuffer_changed)
   {
     RestoreGraphicsAPIState();
-    UpdateVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT, m_vram_ptr, false, false);
+    UpdateVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT, GetVRAMshadowPtr(), false, false);
     UpdateDepthBufferFromMaskBit();
     UpdateDisplay();
     ResetGraphicsAPIState();

--- a/src/core/gpu_hw_opengl.cpp
+++ b/src/core/gpu_hw_opengl.cpp
@@ -256,7 +256,7 @@ void GPU_HW_OpenGL::UpdateSettings()
   if (framebuffer_changed)
   {
     RestoreGraphicsAPIState();
-    UpdateVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT, m_vram_ptr, false, false);
+    UpdateVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT, GetVRAMshadowPtr(), false, false);
     UpdateDepthBufferFromMaskBit();
     UpdateDisplay();
     ResetGraphicsAPIState();

--- a/src/core/gpu_hw_vulkan.cpp
+++ b/src/core/gpu_hw_vulkan.cpp
@@ -228,7 +228,7 @@ void GPU_HW_Vulkan::UpdateSettings()
   if (framebuffer_changed)
   {
     RestoreGraphicsAPIState();
-    UpdateVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT, m_vram_ptr, false, false);
+    UpdateVRAM(0, 0, VRAM_WIDTH, VRAM_HEIGHT, GetVRAMshadowPtr(), false, false);
     UpdateDepthBufferFromMaskBit();
     UpdateDisplay();
     ResetGraphicsAPIState();

--- a/src/core/gpu_sw.cpp
+++ b/src/core/gpu_sw.cpp
@@ -28,9 +28,11 @@ ALWAYS_INLINE static constexpr std::tuple<T, T> MinMax(T v1, T v2)
     return std::tie(v1, v2);
 }
 
+#define GetVramDisplayMemPtr() m_backend.GetUPRAM()
+
 GPU_SW::GPU_SW()
 {
-  m_vram_ptr = m_backend.GetVRAM();
+  //m_vram_ptr = m_backend.GetUPRAM();
 }
 
 GPU_SW::~GPU_SW()
@@ -223,17 +225,20 @@ ALWAYS_INLINE void CopyOutRow16<HostDisplayPixelFormat::BGRA8, u32>(const u16* s
 }
 
 template<HostDisplayPixelFormat display_format>
-void GPU_SW::CopyOut15Bit(u32 src_x, u32 src_y, u32 width, u32 height, u32 field, bool interlaced, bool interleaved)
+void GPU_SW::CopyOut15Bit(u32 src_x_native, u32 src_y_native, u32 width_native, u32 height_native, u32 field, bool interlaced, bool interleaved)
 {
   u8* dst_ptr;
   u32 dst_stride;
+
+  auto width_up  = width_native  * RESOLUTION_SCALE;
+  auto height_up = height_native * RESOLUTION_SCALE;
 
   using OutputPixelType = std::conditional_t<
     display_format == HostDisplayPixelFormat::RGBA8 || display_format == HostDisplayPixelFormat::BGRA8, u32, u16>;
 
   if (!interlaced)
   {
-    if (!m_host_display->BeginSetDisplayPixels(display_format, width, height, reinterpret_cast<void**>(&dst_ptr),
+    if (!m_host_display->BeginSetDisplayPixels(display_format, width_up, height_up, reinterpret_cast<void**>(&dst_ptr),
                                                &dst_stride))
     {
       return;
@@ -249,36 +254,41 @@ void GPU_SW::CopyOut15Bit(u32 src_x, u32 src_y, u32 width, u32 height, u32 field
   const u8 interlaced_shift = BoolToUInt8(interlaced);
   const u8 interleaved_shift = BoolToUInt8(interleaved);
 
+  auto src_x_up = src_x_native * RESOLUTION_SCALE;
+  auto src_y_up = src_y_native * RESOLUTION_SCALE;
+
+  auto m_vram_ptr = GetVramDisplayMemPtr();
+
   // Fast path when not wrapping around.
-  if ((src_x + width) <= VRAM_WIDTH && (src_y + height) <= VRAM_HEIGHT)
+  if ((src_x_native + width_native) <= VRAM_WIDTH && (src_y_native + height_native) <= VRAM_HEIGHT)
   {
-    const u32 rows = height >> interlaced_shift;
+    const u32 rows = height_up >> interlaced_shift;
     dst_stride <<= interlaced_shift;
 
-    const u16* src_ptr = &m_vram_ptr[src_y * VRAM_WIDTH + src_x];
-    const u32 src_step = VRAM_WIDTH << interleaved_shift;
+    const u16* src_ptr = &m_vram_ptr[src_y_up * VRAM_UPRENDER_SIZE_X + src_x_up];
+    const u32 src_step = VRAM_UPRENDER_SIZE_X << interleaved_shift;
     for (u32 row = 0; row < rows; row++)
     {
-      CopyOutRow16<display_format>(src_ptr, reinterpret_cast<OutputPixelType*>(dst_ptr), width);
+      CopyOutRow16<display_format>(src_ptr, reinterpret_cast<OutputPixelType*>(dst_ptr), width_up);
       src_ptr += src_step;
       dst_ptr += dst_stride;
     }
   }
   else
   {
-    const u32 rows = height >> interlaced_shift;
+    const u32 rows = height_up >> interlaced_shift;
     dst_stride <<= interlaced_shift;
 
-    const u32 end_x = src_x + width;
+    const u32 end_x_up = src_x_up + width_up;
     for (u32 row = 0; row < rows; row++)
     {
-      const u16* src_row_ptr = &m_vram_ptr[(src_y % VRAM_HEIGHT) * VRAM_WIDTH];
+      const u16* src_row_ptr = &m_vram_ptr[(src_y_up % VRAM_UPRENDER_SIZE_Y) * VRAM_UPRENDER_SIZE_X];
       OutputPixelType* dst_row_ptr = reinterpret_cast<OutputPixelType*>(dst_ptr);
 
-      for (u32 col = src_x; col < end_x; col++)
-        *(dst_row_ptr++) = VRAM16ToOutput<display_format, OutputPixelType>(src_row_ptr[col % VRAM_WIDTH]);
+      for (u32 col = src_x_up; col < end_x_up; col++)
+        *(dst_row_ptr++) = VRAM16ToOutput<display_format, OutputPixelType>(src_row_ptr[col % VRAM_UPRENDER_SIZE_X]);
 
-      src_y += (1 << interleaved_shift);
+      src_y_up += (1 << interleaved_shift);
       dst_ptr += dst_stride;
     }
   }
@@ -289,7 +299,7 @@ void GPU_SW::CopyOut15Bit(u32 src_x, u32 src_y, u32 width, u32 height, u32 field
   }
   else
   {
-    m_host_display->SetDisplayPixels(display_format, width, height, m_display_texture_buffer.data(), output_stride);
+    m_host_display->SetDisplayPixels(display_format, width_up, height_up, m_display_texture_buffer.data(), output_stride);
   }
 }
 
@@ -316,18 +326,21 @@ void GPU_SW::CopyOut15Bit(HostDisplayPixelFormat display_format, u32 src_x, u32 
 }
 
 template<HostDisplayPixelFormat display_format>
-void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 height, u32 field, bool interlaced,
+void GPU_SW::CopyOut24Bit(u32 src_x_native, u32 src_y_native, u32 skip_x_native, u32 width_native, u32 height_native, u32 field, bool interlaced,
                           bool interleaved)
 {
   u8* dst_ptr;
   u32 dst_stride;
+
+  auto width_up  = width_native  * RESOLUTION_SCALE;
+  auto height_up = height_native * RESOLUTION_SCALE;
 
   using OutputPixelType = std::conditional_t<
     display_format == HostDisplayPixelFormat::RGBA8 || display_format == HostDisplayPixelFormat::BGRA8, u32, u16>;
 
   if (!interlaced)
   {
-    if (!m_host_display->BeginSetDisplayPixels(display_format, width, height, reinterpret_cast<void**>(&dst_ptr),
+    if (!m_host_display->BeginSetDisplayPixels(display_format, width_up, height_up, reinterpret_cast<void**>(&dst_ptr),
                                                &dst_stride))
     {
       return;
@@ -335,27 +348,43 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
   }
   else
   {
-    dst_stride = Common::AlignUpPow2<u32>(width * sizeof(OutputPixelType), 4);
+    dst_stride = GPU_MAX_DISPLAY_WIDTH * sizeof(OutputPixelType);
     dst_ptr = m_display_texture_buffer.data() + (field != 0 ? dst_stride : 0);
   }
 
   const u32 output_stride = dst_stride;
   const u8 interlaced_shift = BoolToUInt8(interlaced);
   const u8 interleaved_shift = BoolToUInt8(interleaved);
-  const u32 rows = height >> interlaced_shift;
+  const u32 rows_native = height_native >> interlaced_shift;
+  const u32 rows = height_up >> interlaced_shift;
+
   dst_stride <<= interlaced_shift;
 
-  if ((src_x + width) <= VRAM_WIDTH && (src_y + (rows << interleaved_shift)) <= VRAM_HEIGHT)
+  auto src_x_up   = src_x_native  * RESOLUTION_SCALE;
+  auto src_y_up   = src_y_native  * RESOLUTION_SCALE;
+  auto skip_x_up  = skip_x_native * RESOLUTION_SCALE;
+
+  // FIXME: 24 bit modes must be sampled either from a native res staging buffer, or by
+  // adapting logic to handle the upres swizzle (due to PSX VMEM being 16-bits natively):
+  //
+  //  1  2  3  4  5  6  7  8  9  10
+  //  RG RG BR BR GB GB RG RG BR BR
+  //  RG RG BR BR GB GB RG RG BR BR
+  //
+
+  auto m_vram_ptr = GetVramDisplayMemPtr();
+
+  if ((src_x_native + width_native) <= VRAM_WIDTH && (src_y_native + (rows_native << interleaved_shift)) <= VRAM_HEIGHT)
   {
-    const u8* src_ptr = reinterpret_cast<const u8*>(&m_vram_ptr[src_y * VRAM_WIDTH + src_x]) + (skip_x * 3);
-    const u32 src_stride = (VRAM_WIDTH << interleaved_shift) * sizeof(u16);
+    const u8* src_ptr = reinterpret_cast<const u8*>(&m_vram_ptr[src_y_up * VRAM_UPRENDER_SIZE_X + src_x_up]) + (skip_x_up * 3);
+    const u32 src_stride = (VRAM_UPRENDER_SIZE_X << interleaved_shift) * sizeof(u16);
     for (u32 row = 0; row < rows; row++)
     {
       if constexpr (display_format == HostDisplayPixelFormat::RGBA8)
       {
         const u8* src_row_ptr = src_ptr;
         u8* dst_row_ptr = reinterpret_cast<u8*>(dst_ptr);
-        for (u32 col = 0; col < width; col++)
+        for (u32 col = 0; col < width_up; col++)
         {
           *(dst_row_ptr++) = *(src_row_ptr++);
           *(dst_row_ptr++) = *(src_row_ptr++);
@@ -367,7 +396,7 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
       {
         const u8* src_row_ptr = src_ptr;
         u8* dst_row_ptr = reinterpret_cast<u8*>(dst_ptr);
-        for (u32 col = 0; col < width; col++)
+        for (u32 col = 0; col < width_up; col++)
         {
           *(dst_row_ptr++) = src_row_ptr[2];
           *(dst_row_ptr++) = src_row_ptr[1];
@@ -380,7 +409,7 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
       {
         const u8* src_row_ptr = src_ptr;
         u16* dst_row_ptr = reinterpret_cast<u16*>(dst_ptr);
-        for (u32 col = 0; col < width; col++)
+        for (u32 col = 0; col < width_up; col++)
         {
           *(dst_row_ptr++) = ((static_cast<u16>(src_row_ptr[0]) >> 3) << 11) |
                              ((static_cast<u16>(src_row_ptr[1]) >> 2) << 5) | (static_cast<u16>(src_row_ptr[2]) >> 3);
@@ -391,7 +420,7 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
       {
         const u8* src_row_ptr = src_ptr;
         u16* dst_row_ptr = reinterpret_cast<u16*>(dst_ptr);
-        for (u32 col = 0; col < width; col++)
+        for (u32 col = 0; col < width_up; col++)
         {
           *(dst_row_ptr++) = ((static_cast<u16>(src_row_ptr[0]) >> 3) << 10) |
                              ((static_cast<u16>(src_row_ptr[1]) >> 3) << 5) | (static_cast<u16>(src_row_ptr[2]) >> 3);
@@ -407,13 +436,13 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
   {
     for (u32 row = 0; row < rows; row++)
     {
-      const u16* src_row_ptr = &m_vram_ptr[(src_y % VRAM_HEIGHT) * VRAM_WIDTH];
+      const u16* src_row_ptr = &m_vram_ptr[(src_y_up % VRAM_UPRENDER_SIZE_Y) * VRAM_UPRENDER_SIZE_X];
       OutputPixelType* dst_row_ptr = reinterpret_cast<OutputPixelType*>(dst_ptr);
 
-      for (u32 col = 0; col < width; col++)
+      for (u32 col = 0; col < width_up; col++)
       {
-        const u32 offset = (src_x + (((skip_x + col) * 3) / 2));
-        const u16 s0 = src_row_ptr[offset % VRAM_WIDTH];
+        const u32 offset = (src_x_up + (((skip_x_up + col) * 3) / 2));
+        const u16 s0 = src_row_ptr[(offset + 0) % VRAM_WIDTH];
         const u16 s1 = src_row_ptr[(offset + 1) % VRAM_WIDTH];
         const u8 shift = static_cast<u8>(col & 1u) * 8;
         const u32 rgb = (((ZeroExtend32(s1) << 16) | ZeroExtend32(s0)) >> shift);
@@ -436,7 +465,7 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
         }
       }
 
-      src_y += (1 << interleaved_shift);
+      src_y_up += (1 << interleaved_shift);
       dst_ptr += dst_stride;
     }
   }
@@ -447,7 +476,7 @@ void GPU_SW::CopyOut24Bit(u32 src_x, u32 src_y, u32 skip_x, u32 width, u32 heigh
   }
   else
   {
-    m_host_display->SetDisplayPixels(display_format, width, height, m_display_texture_buffer.data(), output_stride);
+    m_host_display->SetDisplayPixels(display_format, width_up, height_up, m_display_texture_buffer.data(), output_stride);
   }
 }
 
@@ -482,7 +511,12 @@ void GPU_SW::ClearDisplay()
 void GPU_SW::UpdateDisplay()
 {
   // fill display texture
-  m_backend.Sync();
+  m_backend.Sync(true);
+
+  // FIXME - UPRENDER - this should be implemented by the BACKEND.
+  // In fact, a separation of frontend and backend in GPU software hardly makes sense.
+  // The backends on the HW GPU impl are for platform dependent things: DX11, DX12, Vulkan, etc.
+  // But in software, we have no such thing. It's all platform agnostic. So why the backend?
 
   if (!g_settings.debugging.show_vram)
   {
@@ -534,8 +568,8 @@ void GPU_SW::UpdateDisplay()
   else
   {
     CopyOut15Bit(m_16bit_display_format, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, 0, false, false);
-    m_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT,
-                                         static_cast<float>(VRAM_WIDTH) / static_cast<float>(VRAM_HEIGHT));
+    m_host_display->SetDisplayParameters(VRAM_UPRENDER_SIZE_X, VRAM_UPRENDER_SIZE_Y, 0, 0, VRAM_UPRENDER_SIZE_X, VRAM_UPRENDER_SIZE_Y,
+                                         static_cast<float>(VRAM_UPRENDER_SIZE_X) / static_cast<float>(VRAM_UPRENDER_SIZE_Y));
   }
 }
 
@@ -824,7 +858,14 @@ void GPU_SW::DispatchRenderCommand()
 
 void GPU_SW::ReadVRAM(u32 x, u32 y, u32 width, u32 height)
 {
-  m_backend.Sync();
+  auto* cmd = m_backend.NewReadVRAMCommand();
+  FillBackendCommandParameters(cmd);
+  cmd->x = static_cast<u16>(x);
+  cmd->y = static_cast<u16>(y);
+  cmd->width = static_cast<u16>(width);
+  cmd->height = static_cast<u16>(height);
+  m_backend.PushCommand(cmd);
+  m_backend.Sync(false);
 }
 
 void GPU_SW::FillVRAM(u32 x, u32 y, u32 width, u32 height, u32 color)

--- a/src/core/gpu_sw.h
+++ b/src/core/gpu_sw.h
@@ -16,6 +16,7 @@ public:
   ~GPU_SW() override;
 
   bool IsHardwareRenderer() const override;
+  u16* GetVRAMshadowPtr() override { return m_backend.GetVRAMshadowPtr(); }
 
   bool Initialize(HostDisplay* host_display) override;
   bool DoState(StateWrapper& sw, HostDisplayTexture** host_texture, bool update_display) override;

--- a/src/core/gpu_types.h
+++ b/src/core/gpu_types.h
@@ -15,8 +15,8 @@ enum : u32
   TEXTURE_PAGE_HEIGHT = 256,
 
   // In interlaced modes, we can exceed the 512 height of VRAM, up to 576 in PAL games.
-  GPU_MAX_DISPLAY_WIDTH = 720,
-  GPU_MAX_DISPLAY_HEIGHT = 576,
+  GPU_MAX_DISPLAY_WIDTH = 1440,
+  GPU_MAX_DISPLAY_HEIGHT = 1080,
 
   DITHER_MATRIX_SIZE = 4
 };
@@ -232,6 +232,7 @@ enum class GPUBackendCommandType : u8
 {
   Wraparound,
   Sync,
+  ReadVRAM,
   FillVRAM,
   UpdateVRAM,
   CopyVRAM,
@@ -277,6 +278,14 @@ struct GPUBackendCommand
 
 struct GPUBackendSyncCommand : public GPUBackendCommand
 {
+};
+
+struct GPUBackendReadVRAMCommand : public GPUBackendCommand
+{
+  u16 x;
+  u16 y;
+  u16 width;
+  u16 height;
 };
 
 struct GPUBackendFillVRAMCommand : public GPUBackendCommand


### PR DESCRIPTION
Staged, works when ResolutionScale = 1

staged, works except for FMVs.

Uprender added to DrawSpan. Missing lots still.

broken ...

almost working but I screwed up RGB stepping?

coord post padding reduction fixes some issue.

No resolution shift on UV. It's using the 12-bit precision internally anyway. All is fine.

Most things work, UV seems skewed.

FLOAT stepping added, seems to fix PS logo glitches, but doesn't fix in-game issues.

Added options to quickly switch maths between various float/fixed models.

Fixed up FillVRAM for uprender.

Fixed line rendering.

Add support for VRAM shadow concept to GPU_SW (prep for savestate feature) -- Refactored super-sloppy style

Preliminary hookup for ReadVRAM command. Not entirely necessary... but this is all a mess.