### PR TITLE
Add missing Libretro memorycard type

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -864,11 +864,19 @@ const char* Settings::GetControllerTypeDisplayName(ControllerType type)
   return s_controller_display_names[static_cast<int>(type)];
 }
 
-static std::array<const char*, 4> s_memory_card_type_names = {{"None", "Shared", "PerGame", "PerGameTitle"}};
-static std::array<const char*, 4> s_memory_card_type_display_names = {
+static std::array<const char*, 5> s_memory_card_type_names = {{"None", "Shared", "PerGame", "PerGameTitle", "Libretro" }};
+static std::array<const char*, 5> s_memory_card_type_display_names = {
   {TRANSLATABLE("MemoryCardType", "No Memory Card"), TRANSLATABLE("MemoryCardType", "Shared Between All Games"),
    TRANSLATABLE("MemoryCardType", "Separate Card Per Game (Game Code)"),
-   TRANSLATABLE("MemoryCardType", "Separate Card Per Game (Game Title)")}};
+   TRANSLATABLE("MemoryCardType", "Separate Card Per Game (Game Title)")
+   TRANSLATABLE("MemoryCardType", "Memory Card sharing managed by Libretro")
+}};
+
+// these need to be performed as static assert - if e set the std::array size according to MemoryCardType::Count then
+// it will just null-fill unspecified items and we could still have issues with the descriptions not matching the enum.
+// (todo: generally these enum-to-string things are better implemented as lambda switch statements)
+static_assert(s_memory_card_type_names.size()         == (intmax_t)MemoryCardType::Count);
+static_assert(s_memory_card_type_display_names.size() == (intmax_t)MemoryCardType::Count);
 
 std::optional<MemoryCardType> Settings::ParseMemoryCardTypeName(const char* str)
 {


### PR DESCRIPTION
@kivutar  I'm not positive about the description for the libretro memcard mode, but my hinch ios "it's managed by libretro" - please fix to something better if that's not accurate. :)
