### PR TITLE
Hackfix to disable fastmem rewrite feature, works around segfault problem on ludo

### DIFF
--- a/src/core/cpu_recompiler_code_generator_generic.cpp
+++ b/src/core/cpu_recompiler_code_generator_generic.cpp
@@ -61,7 +61,7 @@ Value CodeGenerator::EmitLoadGuestMemory(const CodeBlockInstruction& cbi, const 
 
   Value result = m_register_cache.AllocateScratch(HostPointerSize);
 
-  const bool use_fastmem =
+  const bool use_fastmem = 0 &&
     (address_spec ? Bus::CanUseFastmemForAddress(*address_spec) : true) && !SpeculativeIsCacheIsolated();
   if (address_spec)
   {
@@ -131,7 +131,7 @@ void CodeGenerator::EmitStoreGuestMemory(const CodeBlockInstruction& cbi, const 
 
   AddPendingCycles(true);
 
-  const bool use_fastmem =
+  const bool use_fastmem = 0 && 
     (address_spec ? Bus::CanUseFastmemForAddress(*address_spec) : true) && !SpeculativeIsCacheIsolated();
   if (address_spec)
   {


### PR DESCRIPTION
It should be better to uncover the reason why ludo (golang, more likely) is interfering with the PageFault/SegFault handler on Windows.